### PR TITLE
Add API key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 [![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/rtargi/skills-github-pages/issues/1)
 
+## API key
+
+To use examples that access an external API, you must provide an API key. Replace the empty string in `index.html` with your key or set the `API_KEY` environment variable before building the site.
+
 ---
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)


### PR DESCRIPTION
## Summary
- document how to supply an API key

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c7d54bacc83328b685c105e1d7985